### PR TITLE
Add support for Windows (for some utilities)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,7 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (git+https://github.com/mesalock-linux/glob)",
  "globset 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -425,6 +426,7 @@ dependencies = [
  "trust-dns-resolver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1 (git+https://github.com/uutils/coreutils)",
  "walkdir 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ clap = "2.31.2"
 failure = "0.1.1"
 failure_derive = "0.1.1"
 kernel32-sys = "0.2.2"
-winapi = "0.3.5"
+winapi = { version = "0.3.5", features = ["namedpipeapi"] }
 libc = "0.2.40"
 nix = "0.10.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,12 +53,38 @@ sysinit = [
     "init"
 ]
 
-default = ["gnu", "loginutils", "lsb", "networking", "posix", "sysinit"]
+# utilities that work on Unix
+unix = [
+    "gnu",
+    "loginutils",
+    "lsb",
+    "networking",
+    "posix",
+    "sysinit",
+]
+
+# utilities that work on Windows
+windows = [
+    "gnu",
+
+    "cat",
+    "echo",
+    "head",
+    "sleep",
+]
+
+# the following are real features (rather than utilities)
+# used to prioritize latency over throughput in utilites that care
+latency = []
+
+default = ["unix"]
 
 [dependencies]
 clap = "2.31.2"
 failure = "0.1.1"
 failure_derive = "0.1.1"
+kernel32-sys = "0.2.2"
+winapi = "0.3.5"
 libc = "0.2.40"
 nix = "0.10.0"
 

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,0 +1,26 @@
+use std::io::{Read, Write};
+use std::net::TcpStream;
+
+const FILE_DATA: &str = r#"
+            this is a collection of text
+this should be printed
+    so should this
+but this shouldn't
+more stuff down here
+
+
+
+
+stuff
+"#;
+
+fn main() {
+    let mut stream = TcpStream::connect("127.0.0.1:9876").unwrap();
+
+    writeln!(stream, "{}", FILE_DATA).unwrap();
+
+    let mut result = String::new();
+    stream.read_to_string(&mut result).unwrap();
+
+    println!("result from server: {}", result);
+}

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,10 +1,8 @@
 extern crate mesabox;
 
 use mesabox::UtilData;
-use std::env;
-use std::io::{self, Read, Write};
+use std::io::Write;
 use std::iter;
-use std::process;
 
 use std::net::TcpListener;
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -18,7 +18,8 @@ fn main() {
         let mut stderr = stream.try_clone().unwrap();
 
         let res = {
-            let mut setup = UtilData::new(&mut stream, &mut stdout, &mut stderr, iter::empty(), None);
+            let mut setup =
+                UtilData::new(&mut stream, &mut stdout, &mut stderr, iter::empty(), None);
 
             mesabox::execute(&mut setup, &mut ["head", "-n", "4"].into_iter())
         };

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,0 +1,29 @@
+extern crate mesabox;
+
+use mesabox::UtilData;
+use std::env;
+use std::io::{self, Read, Write};
+use std::iter;
+use std::process;
+
+use std::net::TcpListener;
+
+fn main() {
+    let listener = TcpListener::bind("127.0.0.1:9876").unwrap();
+
+    for stream in listener.incoming() {
+        let mut stream = stream.unwrap();
+
+        let mut stdout = stream.try_clone().unwrap();
+        let mut stderr = stream.try_clone().unwrap();
+
+        let res = {
+            let mut setup = UtilData::new(&mut stream, &mut stdout, &mut stderr, iter::empty(), None);
+
+            mesabox::execute(&mut setup, &mut ["head", "-n", "4"].into_iter())
+        };
+        if let Err(f) = res {
+            let _ = writeln!(stderr, "{}", f);
+        }
+    }
+}

--- a/src/gnu/base32/common.rs
+++ b/src/gnu/base32/common.rs
@@ -102,13 +102,13 @@ where
             let file = File::open(path)?;
 
             let mut output = setup.output();
-            let output = output.lock_writer()?;
+            let output = output.lock()?;
             handle_data(output, BufReader::new(file), options)
         }
         _ => {
             let (mut input, mut output, _) = setup.stdio();
-            let input = input.lock_reader()?;
-            let output = output.lock_writer()?;
+            let input = input.lock()?;
+            let output = output.lock()?;
             handle_data(output, input, options)
         }
     }

--- a/src/gnu/yes/mod.rs
+++ b/src/gnu/yes/mod.rs
@@ -35,7 +35,7 @@ use {UtilSetup, Result, ArgsIter, UtilWrite};
 
 use clap::Arg;
 use std::borrow::Cow;
-use std::ffi::{OsString, OsStr};
+use std::ffi::OsStr;
 use std::io::Write;
 
 use util::OsStrExt;
@@ -67,9 +67,10 @@ where
             res
         });
         result.push(OsStr::new("\n"));
-        Cow::from(result)
+        // XXX: interestingly, Cow::from() only seems to work on Windows for OsString/OsStr
+        Cow::Owned(result)
     } else {
-        Cow::from(OsStr::new("y\n"))
+        Cow::Borrowed(OsStr::new("y\n"))
     };
 
     let bytes = string.try_as_bytes()?;

--- a/src/gnu/yes/mod.rs
+++ b/src/gnu/yes/mod.rs
@@ -108,7 +108,7 @@ where
     S: UtilSetup,
 {
     let stdout = setup.output();
-    let mut stdout = stdout.lock_writer()?;
+    let mut stdout = stdout.lock()?;
     loop {
         stdout.write_all(bytes)?;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,13 @@ extern crate failure;
 #[macro_use]
 extern crate failure_derive;
 extern crate libc;
+
+#[cfg(unix)]
 extern crate nix;
+#[cfg(windows)]
+extern crate kernel32;
+#[cfg(windows)]
+extern crate winapi;
 
 #[cfg(feature = "byteorder")]
 extern crate byteorder;
@@ -54,11 +60,11 @@ use std::env::{self, VarsOs};
 use std::ffi::{OsStr, OsString};
 use std::io::{self, BufRead, Read, Stderr, Stdin, Stdout, Write};
 use std::iter;
-use std::os::unix::io::RawFd;
 use std::path::{Path, PathBuf};
 use std::result::Result as StdResult;
 
 pub use error::*;
+pub(crate) use platform::*;
 pub use setup::*;
 #[allow(unused)]
 pub(crate) use util::*;
@@ -67,6 +73,7 @@ mod error;
 #[macro_use]
 #[allow(unused_macros)]
 mod macros;
+mod platform;
 mod setup;
 #[allow(dead_code)]
 mod util;
@@ -313,7 +320,7 @@ pub trait UtilRead<'a>: LockableRead<'a> {
 
     fn lock_reader<'b: 'a>(&'b mut self) -> StdResult<Self::Lock, LockError>;
 
-    fn raw_fd(&self) -> Option<RawFd> {
+    fn raw_object(&self) -> Option<RawObject> {
         None
     }
 }
@@ -323,7 +330,7 @@ pub trait UtilWrite<'a>: LockableWrite<'a> {
 
     fn lock_writer<'b: 'a>(&'b mut self) -> StdResult<Self::Lock, LockError>;
 
-    fn raw_fd(&self) -> Option<RawFd> {
+    fn raw_object(&self) -> Option<RawObject> {
         None
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ macro_rules! generate_fns {
             S: UtilSetup,
         {
             let stdout = setup.output();
-            let mut stdout = stdout.lock_writer()?;
+            let mut stdout = stdout.lock()?;
 
             $($(
                 #[cfg(feature = $feature)]
@@ -308,17 +308,17 @@ where
 }
 
 pub trait LockableRead<'a>: Read + Send + Sync {
-    fn lock_reader_dyn<'b: 'a>(&'b mut self) -> StdResult<Box<BufRead + 'a>, LockError>;
+    fn lock_dyn<'b: 'a>(&'b mut self) -> StdResult<Box<BufRead + 'a>, LockError>;
 }
 
 pub trait LockableWrite<'a>: Write + Send + Sync {
-    fn lock_writer_dyn<'b: 'a>(&'b mut self) -> StdResult<Box<Write + 'a>, LockError>;
+    fn lock_dyn<'b: 'a>(&'b mut self) -> StdResult<Box<Write + 'a>, LockError>;
 }
 
 pub trait UtilRead<'a>: LockableRead<'a> {
     type Lock: BufRead + 'a;
 
-    fn lock_reader<'b: 'a>(&'b mut self) -> StdResult<Self::Lock, LockError>;
+    fn lock<'b: 'a>(&'b mut self) -> StdResult<Self::Lock, LockError>;
 
     fn raw_object(&self) -> Option<RawObject> {
         None
@@ -328,7 +328,7 @@ pub trait UtilRead<'a>: LockableRead<'a> {
 pub trait UtilWrite<'a>: LockableWrite<'a> {
     type Lock: Write + 'a;
 
-    fn lock_writer<'b: 'a>(&'b mut self) -> StdResult<Self::Lock, LockError>;
+    fn lock<'b: 'a>(&'b mut self) -> StdResult<Self::Lock, LockError>;
 
     fn raw_object(&self) -> Option<RawObject> {
         None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,10 +13,10 @@ extern crate failure;
 extern crate failure_derive;
 extern crate libc;
 
-#[cfg(unix)]
-extern crate nix;
 #[cfg(windows)]
 extern crate kernel32;
+#[cfg(unix)]
+extern crate nix;
 #[cfg(windows)]
 extern crate winapi;
 

--- a/src/networking/ping/mod.rs
+++ b/src/networking/ping/mod.rs
@@ -345,7 +345,7 @@ where
 
     let addr = socket::SockAddr::new_inet(socket::InetAddr::from_std(&options.sock_addr));
 
-    let mut stdout = stdout.lock_writer()?;
+    let mut stdout = stdout.lock()?;
     while options.count.unwrap_or(1) > 0 && !should_stop.load(Ordering::Acquire) {
         let request = IcmpPacket::new(icmp_kind, ident, seq_num);
         // FIXME: should print error rather than return
@@ -451,7 +451,7 @@ where
     set.thread_set_mask()?;
 
     let stdout = setup.output();
-    let mut stdout = stdout.lock_writer()?;
+    let mut stdout = stdout.lock()?;
 
     writeln!(stdout, "\n--- {} ping statistics ---", hostname)?;
     writeln!(stdout, "{} packets transmitted, {} packets received, {}% packet loss", stats.sent, stats.received, stats.packet_loss())?;

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -18,3 +18,7 @@ pub struct Utf8Error(OsString);
 pub trait OsStrExt {
     fn try_as_bytes(&self) -> Result<&[u8], Utf8Error>;
 }
+
+pub trait AsRawObject {
+    fn as_raw_object(&self) -> RawObject;
+}

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -22,3 +22,9 @@ pub trait OsStrExt {
 pub trait AsRawObject {
     fn as_raw_object(&self) -> RawObject;
 }
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+enum PipeKind {
+    Read,
+    Write,
+}

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,0 +1,20 @@
+#[cfg(unix)]
+pub use self::unix::*;
+#[cfg(windows)]
+pub use self::windows::*;
+
+use std::ffi::OsString;
+
+#[cfg(unix)]
+mod unix;
+#[cfg(windows)]
+mod windows;
+
+#[derive(Debug, Fail)]
+#[fail(display = "invalid UTF 8 in {:?}", _0)]
+pub struct Utf8Error(OsString);
+
+/// This trait just exists to convert OsStr to byte slices on Windows basically.
+pub trait OsStrExt {
+    fn try_as_bytes(&self) -> Result<&[u8], Utf8Error>;
+}

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -7,7 +7,7 @@ use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::process::Stdio;
 
-use super::AsRawObject;
+use super::{AsRawObject, PipeKind};
 
 impl super::OsStrExt for OsStr {
     fn try_as_bytes(&self) -> Result<&[u8], super::Utf8Error> {
@@ -109,12 +109,6 @@ impl Write for RawObjectWrapper {
         // XXX: may want to try fsync() or something and ignore failures due to invalid fd type
         Ok(())
     }
-}
-
-#[derive(Copy, Clone, Debug, PartialEq)]
-enum PipeKind {
-    Read,
-    Write,
 }
 
 /// An platform-independent abstraction for pipes that automatically closes the pipe on drop.

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -55,7 +55,8 @@ impl RawObjectWrapper {
     pub fn try_from(fd: RawObject) -> io::Result<Self> {
         use nix::fcntl::OFlag;
 
-        let res = fcntl::fcntl(fd.raw_value(), fcntl::F_GETFL).map_err(|_| io::Error::last_os_error())?;
+        let res =
+            fcntl::fcntl(fd.raw_value(), fcntl::F_GETFL).map_err(|_| io::Error::last_os_error())?;
         let mode = OFlag::from_bits(res & OFlag::O_ACCMODE.bits()).unwrap();
 
         Ok(RawObjectWrapper::new(
@@ -150,7 +151,10 @@ impl Pipe {
     #[cfg(feature = "sh")]
     pub fn try_clone(&self) -> io::Result<Self> {
         let obj = RawObjectWrapper::new(RawObject(self.fd), true, true).dup_sh()?;
-        Ok(Pipe { fd: obj.raw_value(), kind: self.kind })
+        Ok(Pipe {
+            fd: obj.raw_value(),
+            kind: self.kind,
+        })
     }
 
     fn new_read(fd: RawFd) -> Self {

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -1,0 +1,140 @@
+use std::ffi::OsStr;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::io::{AsRawFd, RawFd};
+
+impl super::OsStrExt for OsStr {
+    fn try_as_bytes(&self) -> Option<&[u8]> {
+        self.as_bytes()
+    }
+}
+
+pub type RawObject = RawFd;
+
+/// A wrapper around a raw file descriptor that enables reading and writing using the standard
+/// traits.  Take note that this wrapper does *NOT* close the file descriptor when dropping.
+#[derive(Clone, Debug)]
+pub struct RawObjectWrapper {
+    pub fd: RawObject,
+    pub readable: bool,
+    pub writable: bool,
+}
+// TODO: add way to determine if fd is readable and/or writable
+
+impl RawObjectWrapper {
+    pub fn new(fd: RawObject, readable: bool, writable: bool) -> Self {
+        Self {
+            fd: fd,
+            readable: readable,
+            writable: writable,
+        }
+    }
+
+    // implement here until TryFrom trait is stable
+    pub fn try_from(fd: RawObject) -> nix::Result<Self> {
+        use nix::fcntl::OFlag;
+
+        let res = fcntl::fcntl(fd, fcntl::F_GETFL)?;
+        let mode = OFlag::from_bits(res & OFlag::O_ACCMODE.bits()).unwrap();
+
+        Ok(RawObjectWrapper::new(
+            fd,
+            mode == OFlag::O_RDONLY || mode == OFlag::O_RDWR,
+            mode == OFlag::O_WRONLY || mode == OFlag::O_RDWR,
+        ))
+    }
+
+    /// Duplicate a file descriptor such that it is greater than or equal to `min`.
+    pub fn dup_above(&self, min: RawObject) -> nix::Result<RawObject> {
+        fcntl::fcntl(self.fd, fcntl::F_DUPFD(min))
+    }
+
+    /// Duplicate a file descriptor such that it is greater than or equal to 10.
+    #[cfg(feature = "sh")]
+    pub fn dup_sh(&self) -> nix::Result<RawObject> {
+        self.dup_above(::posix::sh::option::FD_COUNT as RawFd + 1)
+    }
+}
+
+impl Read for RawObjectWrapper {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        unistd::read(self.fd, buf).map_err(|_| io::Error::last_os_error())
+    }
+}
+
+impl Write for RawObjectWrapper {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        unistd::write(self.fd, buf).map_err(|_| io::Error::last_os_error())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        // XXX: may want to try fsync() or something and ignore failures due to invalid fd type
+        Ok(())
+    }
+}
+
+/// Determine whether the given file descriptor is a TTY.
+pub(crate) fn is_tty(stream: Option<RawObject>) -> bool {
+    stream
+        .map(|fd| unsafe { libc::isatty(fd) == 1 })
+        .unwrap_or(false)
+}
+
+impl<'a> UtilRead<'a> for File {
+    type Lock = BufReader<&'a mut Self>;
+
+    fn lock_reader<'b: 'a>(&'b mut self) -> StdResult<Self::Lock, LockError> {
+        Ok(BufReader::new(self))
+    }
+
+    fn raw_fd(&self) -> Option<RawFd> {
+        Some(self.as_raw_fd())
+    }
+}
+
+impl<'a> UtilRead<'a> for io::Stdin {
+    type Lock = io::StdinLock<'a>;
+
+    fn lock_reader<'b: 'a>(&'b mut self) -> StdResult<Self::Lock, LockError> {
+        Ok(self.lock())
+    }
+
+    fn raw_fd(&self) -> Option<RawFd> {
+        Some(self.as_raw_fd())
+    }
+}
+
+impl<'a> UtilWrite<'a> for File {
+    type Lock = BufWriter<&'a mut Self>;
+
+    fn lock_writer<'b: 'a>(&'b mut self) -> StdResult<Self::Lock, LockError> {
+        Ok(BufWriter::new(self))
+    }
+
+    fn raw_fd(&self) -> Option<RawFd> {
+        Some(self.as_raw_fd())
+    }
+}
+
+impl<'a> UtilWrite<'a> for io::Stdout {
+    type Lock = io::StdoutLock<'a>;
+
+    fn lock_writer<'b: 'a>(&'b mut self) -> StdResult<Self::Lock, LockError> {
+        Ok(self.lock())
+    }
+
+    fn raw_fd(&self) -> Option<RawFd> {
+        Some(self.as_raw_fd())
+    }
+}
+
+impl<'a> UtilWrite<'a> for io::Stderr {
+    type Lock = io::StderrLock<'a>;
+
+    fn lock_writer<'b: 'a>(&'b mut self) -> StdResult<Self::Lock, LockError> {
+        Ok(self.lock())
+    }
+
+    fn raw_fd(&self) -> Option<RawFd> {
+        Some(self.as_raw_fd())
+    }
+}

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1,15 +1,18 @@
 use kernel32;
 use winapi::shared::{minwindef, ntdef};
 use winapi::um::winnt::DUPLICATE_SAME_ACCESS;
-use winapi::um::{consoleapi, fileapi};
+use winapi::um::{consoleapi, fileapi, handleapi, namedpipeapi};
+use winapi::um::minwinbase::SECURITY_ATTRIBUTES;
 
 use std::ffi::OsStr;
 use std::fs::File;
-use std::io::{self, BufReader, BufWriter, Read, Write};
-use std::os::windows::io::{AsRawHandle, RawHandle};
+use std::io::{self, Read, Write};
+use std::mem;
+use std::net::TcpStream;
+use std::os::windows::io::{AsRawHandle, AsRawSocket, RawHandle, RawSocket};
 use std::ptr;
 
-use {LockError, UtilRead, UtilWrite};
+use super::{AsRawObject, PipeKind};
 
 impl super::OsStrExt for OsStr {
     fn try_as_bytes(&self) -> Result<&[u8], super::Utf8Error> {
@@ -22,15 +25,40 @@ impl super::OsStrExt for OsStr {
 
 // The system native representation of files, stdin/stdout/stderr, etc.
 #[derive(Copy, Clone, Debug)]
-pub struct RawObject(RawHandle);
+pub enum RawObject {
+    Handle(RawHandle),
+    Socket(RawSocket),
+}
 
 impl RawObject {
     pub fn new(handle: RawHandle) -> Self {
-        RawObject(handle)
+        RawObject::Handle(handle)
     }
 
-    pub fn raw_value(&self) -> RawHandle {
-        self.0
+    pub fn raw_handle(&self) -> Option<RawHandle> {
+        match self {
+            RawObject::Handle(handle) => Some(*handle),
+            _ => None,
+        }
+    }
+
+    pub fn raw_socket(&self) -> Option<RawSocket> {
+        match self {
+            RawObject::Socket(socket) => Some(*socket),
+            _ => None,
+        }
+    }
+}
+
+impl From<RawHandle> for RawObject {
+    fn from(handle: RawHandle) -> Self {
+        RawObject::Handle(handle)
+    }
+}
+
+impl From<RawSocket> for RawObject {
+    fn from(socket: RawSocket) -> Self {
+        RawObject::Socket(socket)
     }
 }
 
@@ -85,33 +113,48 @@ impl RawObjectWrapper {
     }
 
     pub fn dup(&self) -> io::Result<RawObject> {
-        let mut duplicate = ptr::null_mut();
-        let res = unsafe {
-            kernel32::DuplicateHandle(
-                kernel32::GetCurrentProcess(),
-                self.object.0,
-                kernel32::GetCurrentProcess(),
-                &mut duplicate,
-                0,
-                minwindef::FALSE,
-                DUPLICATE_SAME_ACCESS,
-            )
-        };
-        // == 0 is correct
-        if res == 0 {
-            Err(io::Error::last_os_error())
-        } else {
-            Ok(RawObject(duplicate))
+        match self.object {
+            RawObject::Handle(handle) => {
+                let mut duplicate = ptr::null_mut();
+                let res = unsafe {
+                    kernel32::DuplicateHandle(
+                        kernel32::GetCurrentProcess(),
+                        handle,
+                        kernel32::GetCurrentProcess(),
+                        &mut duplicate,
+                        0,
+                        minwindef::FALSE,
+                        DUPLICATE_SAME_ACCESS,
+                    )
+                };
+                // == 0 is correct
+                if res == 0 {
+                    Err(io::Error::last_os_error())
+                } else {
+                    Ok(RawObject::Handle(duplicate))
+                }
+            }
+            RawObject::Socket(socket) => {
+                // TODO: call WSADuplicateSocketW() and use the returned info to create a new
+                //       socket using WSASocket()
+                unimplemented!()
+            }
         }
     }
 }
 
 impl Read for RawObjectWrapper {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        // according to the docs, a socket handle can be used with ReadFile()
+        let handle = match self.object {
+            RawObject::Handle(handle) => handle,
+            RawObject::Socket(socket) => socket as _,
+        };
+
         let mut bytes_read = 0;
         let res = unsafe {
             fileapi::ReadFile(
-                self.object.0,
+                handle,
                 buf.as_mut_ptr() as _,
                 buf.len() as _,
                 &mut bytes_read,
@@ -128,10 +171,16 @@ impl Read for RawObjectWrapper {
 
 impl Write for RawObjectWrapper {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        // according to the docs, a socket handle can be used with WriteFile()
+        let handle = match self.object {
+            RawObject::Handle(handle) => handle,
+            RawObject::Socket(socket) => socket as _,
+        };
+
         let mut bytes_written = 0;
         let res = unsafe {
             fileapi::WriteFile(
-                self.object.0,
+                handle,
                 buf.as_ptr() as _,
                 buf.len() as _,
                 &mut bytes_written,
@@ -151,73 +200,167 @@ impl Write for RawObjectWrapper {
     }
 }
 
+/// An platform-independent abstraction for pipes that automatically closes the pipe on drop.
+#[derive(Debug)]
+pub struct Pipe {
+    handle: RawHandle,
+    kind: PipeKind,
+}
+
+impl Pipe {
+    pub fn create() -> io::Result<(Self, Self)> {
+        let mut read = ptr::null_mut();
+        let mut write = ptr::null_mut();
+        let mut attributes = SECURITY_ATTRIBUTES {
+            nLength: mem::size_of::<SECURITY_ATTRIBUTES>() as _,
+            lpSecurityDescriptor: ptr::null_mut(),
+            bInheritHandle: minwindef::TRUE,
+        };
+        let res = unsafe {
+            namedpipeapi::CreatePipe(
+                &mut read,
+                &mut write,
+                &mut attributes,
+                0
+            )
+        };
+        if res == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok((Pipe::new_read(read), Pipe::new_write(write)))
+        }
+    }
+
+    pub fn readable(&self) -> bool {
+        self.kind == PipeKind::Read
+    }
+
+    pub fn writable(&self) -> bool {
+        self.kind == PipeKind::Write
+    }
+
+    // XXX: might be better to only allow conversion to RawObjectWrapper
+    pub fn raw_object(&self) -> RawObject {
+        RawObject::Handle(self.handle)
+    }
+
+    pub fn raw_object_wrapper(&self) -> RawObjectWrapper {
+        RawObjectWrapper::new(RawObject::Handle(self.handle), self.readable(), self.writable())
+    }
+
+    // FIXME: not sure if we really want to dup here
+    #[cfg(feature = "sh")]
+    pub fn try_clone(&self) -> io::Result<Self> {
+        let obj = RawObjectWrapper::new(RawObject::Handle(self.handle), true, true).dup_sh()?;
+        Ok(Pipe {
+            handle: obj.raw_value(),
+            kind: self.kind,
+        })
+    }
+
+    fn new_read(handle: RawHandle) -> Self {
+        Self {
+            handle,
+            kind: PipeKind::Read,
+        }
+    }
+
+    fn new_write(handle: RawHandle) -> Self {
+        Self {
+            handle,
+            kind: PipeKind::Write,
+        }
+    }
+}
+
+impl Read for Pipe {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        RawObjectWrapper::new(RawObject::new(self.handle), true, false).read(buf)
+    }
+}
+
+impl Write for Pipe {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        RawObjectWrapper::new(RawObject::new(self.handle), false, true).write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        RawObjectWrapper::new(RawObject::new(self.handle), false, true).flush()
+    }
+}
+
+impl AsRawObject for Pipe {
+    fn as_raw_object(&self) -> RawObject {
+        RawObject::Handle(self.handle)
+    }
+}
+
+impl Drop for Pipe {
+    fn drop(&mut self) {
+        // XXX: ignore error?
+        unsafe {
+            handleapi::CloseHandle(self.handle);
+        }
+    }
+}
+
 /// Determine whether the given file descriptor is a TTY.
 pub(crate) fn is_tty(stream: Option<RawObject>) -> bool {
     stream
         .map(|obj| {
-            let mut out = 0;
-            let res = unsafe { consoleapi::GetConsoleMode(obj.0, &mut out) };
-            res != 0
+            match obj {
+                RawObject::Handle(handle) => {
+                    let mut out = 0;
+                    let res = unsafe { consoleapi::GetConsoleMode(handle, &mut out) };
+                    res != 0
+                }
+                _ => false,
+            }
         })
         .unwrap_or(false)
 }
 
-impl<'a> UtilRead<'a> for File {
-    type Lock = BufReader<&'a mut Self>;
-
-    fn lock_reader<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
-        Ok(BufReader::new(self))
-    }
-
-    fn raw_object(&self) -> Option<RawObject> {
-        Some(RawObject(self.as_raw_handle()))
+impl AsRawObject for File {
+    fn as_raw_object(&self) -> RawObject {
+        RawObject::Handle(self.as_raw_handle())
     }
 }
 
-impl<'a> UtilRead<'a> for io::Stdin {
-    type Lock = io::StdinLock<'a>;
-
-    fn lock_reader<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
-        Ok(self.lock())
-    }
-
-    fn raw_object(&self) -> Option<RawObject> {
-        Some(RawObject(self.as_raw_handle()))
+impl AsRawObject for io::Stdin {
+    fn as_raw_object(&self) -> RawObject {
+        RawObject::Handle(self.as_raw_handle())
     }
 }
 
-impl<'a> UtilWrite<'a> for File {
-    type Lock = BufWriter<&'a mut Self>;
-
-    fn lock_writer<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
-        Ok(BufWriter::new(self))
-    }
-
-    fn raw_object(&self) -> Option<RawObject> {
-        Some(RawObject(self.as_raw_handle()))
+impl AsRawObject for io::Stdout {
+    fn as_raw_object(&self) -> RawObject {
+        RawObject::Handle(self.as_raw_handle())
     }
 }
 
-impl<'a> UtilWrite<'a> for io::Stdout {
-    type Lock = io::StdoutLock<'a>;
-
-    fn lock_writer<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
-        Ok(self.lock())
-    }
-
-    fn raw_object(&self) -> Option<RawObject> {
-        Some(RawObject(self.as_raw_handle()))
+impl AsRawObject for io::Stderr {
+    fn as_raw_object(&self) -> RawObject {
+        RawObject::Handle(self.as_raw_handle())
     }
 }
 
-impl<'a> UtilWrite<'a> for io::Stderr {
-    type Lock = io::StderrLock<'a>;
-
-    fn lock_writer<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
-        Ok(self.lock())
-    }
-
-    fn raw_object(&self) -> Option<RawObject> {
-        Some(RawObject(self.as_raw_handle()))
+impl AsRawObject for TcpStream {
+    fn as_raw_object(&self) -> RawObject {
+        RawObject::Socket(self.as_raw_socket())
     }
 }
+
+// would very much like to do this but doesn't work
+/*
+impl<T: AsRawHandle> AsRawObject for T {
+    fn as_raw_object(&self) -> RawObject {
+        RawObject::Handle(self.as_raw_handle())
+    }
+}
+
+impl<T: AsRawSocket> AsRawObject for T {
+    fn as_raw_object(&self) -> RawObject {
+        RawObject::Socket(self.as_raw_socket())
+    }
+}
+*/

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -24,6 +24,16 @@ impl super::OsStrExt for OsStr {
 #[derive(Copy, Clone, Debug)]
 pub struct RawObject(RawHandle);
 
+impl RawObject {
+    pub fn new(handle: RawHandle) -> Self {
+        RawObject(handle)
+    }
+
+    pub fn raw_value(&self) -> RawHandle {
+        self.0
+    }
+}
+
 unsafe impl Send for RawObject { }
 unsafe impl Sync for RawObject { }
 
@@ -56,6 +66,11 @@ impl RawObjectWrapper {
         unimplemented!()
     }
 
+    /// Duplicate a file descriptor such that its new value is `val`.  This is equivalent to `dup2`.
+    pub fn dup_as(&self, val: RawObject) -> io::Result<RawObject> {
+        unimplemented!()
+    }
+
     /// Duplicate a file descriptor such that it is greater than or equal to `min`.
     pub fn dup_above(&self, min: RawObject) -> io::Result<RawObject> {
         // FIXME: dunno how to do this atm
@@ -65,7 +80,8 @@ impl RawObjectWrapper {
     /// Duplicate a file descriptor such that it is greater than or equal to 10.
     #[cfg(feature = "sh")]
     pub fn dup_sh(&self) -> io::Result<RawObject> {
-        self.dup_above(::posix::sh::option::FD_COUNT as RawObject + 1)
+        unimplemented!()
+        //self.dup_above(::posix::sh::option::FD_COUNT as RawObject + 1)
     }
 
     pub fn dup(&self) -> io::Result<RawObject> {

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1,0 +1,190 @@
+use kernel32;
+use winapi::um::winnt::DUPLICATE_SAME_ACCESS;
+use winapi::um::{consoleapi, fileapi};
+use winapi::shared::{ntdef, minwindef};
+
+use std::ffi::OsStr;
+use std::fs::File;
+use std::io::{self, BufReader, BufWriter, Read, Write};
+use std::os::windows::io::{AsRawHandle, RawHandle};
+use std::ptr;
+
+use {UtilRead, UtilWrite, LockError};
+
+impl super::OsStrExt for OsStr {
+    fn try_as_bytes(&self) -> Result<&[u8], super::Utf8Error> {
+        match self.to_str() {
+            Some(s) => Ok(s.as_bytes()),
+            None => Err(super::Utf8Error(self.to_owned())),
+        }
+    }
+}
+
+// The system native representation of files, stdin/stdout/stderr, etc.
+#[derive(Copy, Clone, Debug)]
+pub struct RawObject(RawHandle);
+
+unsafe impl Send for RawObject { }
+unsafe impl Sync for RawObject { }
+
+/// A wrapper around a raw handle that enables reading and writing using the standard traits.  Take
+/// note that this wrapper does *NOT* close the file descriptor when dropping.
+#[derive(Clone, Debug)]
+pub struct RawObjectWrapper {
+    pub object: RawObject,
+    pub readable: bool,
+    pub writable: bool,
+}
+// TODO: add way to determine if fd is readable and/or writable
+
+impl RawObjectWrapper {
+    pub fn new(handle: RawObject, readable: bool, writable: bool) -> Self {
+        Self {
+            object: handle,
+            readable: readable,
+            writable: writable,
+        }
+    }
+
+    pub fn inner_object(&self) -> RawObject {
+        self.object
+    }
+
+    // implement here until TryFrom trait is stable
+    pub fn try_from(fd: RawObject) -> io::Result<Self> {
+        // FIXME: dunno how to do this atm
+        unimplemented!()
+    }
+
+    /// Duplicate a file descriptor such that it is greater than or equal to `min`.
+    pub fn dup_above(&self, min: RawObject) -> io::Result<RawObject> {
+        // FIXME: dunno how to do this atm
+        unimplemented!()
+    }
+
+    /// Duplicate a file descriptor such that it is greater than or equal to 10.
+    #[cfg(feature = "sh")]
+    pub fn dup_sh(&self) -> io::Result<RawObject> {
+        self.dup_above(::posix::sh::option::FD_COUNT as RawObject + 1)
+    }
+
+    pub fn dup(&self) -> io::Result<RawObject> {
+        let mut duplicate = ptr::null_mut();
+        let res = unsafe {
+            kernel32::DuplicateHandle(
+                kernel32::GetCurrentProcess(),
+                self.object.0,
+                kernel32::GetCurrentProcess(),
+                &mut duplicate,
+                0,
+                minwindef::FALSE,
+                DUPLICATE_SAME_ACCESS
+            )
+        };
+        // == 0 is correct
+        if res == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(RawObject(duplicate))
+        }
+    }
+}
+
+impl Read for RawObjectWrapper {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut bytes_read = 0;
+        let res = unsafe { fileapi::ReadFile(self.object.0, buf.as_mut_ptr() as _, buf.len() as _, &mut bytes_read, ntdef::NULL as _) };
+        if res == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(bytes_read as _)
+        }
+    }
+}
+
+impl Write for RawObjectWrapper {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut bytes_written = 0;
+        let res = unsafe { fileapi::WriteFile(self.object.0, buf.as_ptr() as _, buf.len() as _, &mut bytes_written, ntdef::NULL as _) };
+        if res == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(bytes_written as _)
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        // XXX: may want to try fsync() or something and ignore failures due to invalid fd type
+        Ok(())
+    }
+}
+
+/// Determine whether the given file descriptor is a TTY.
+pub(crate) fn is_tty(stream: Option<RawObject>) -> bool {
+    stream
+        .map(|obj| {
+            let mut out = 0;
+            let res = unsafe { consoleapi::GetConsoleMode(obj.0, &mut out) };
+            res != 0
+        }).unwrap_or(false)
+}
+
+impl<'a> UtilRead<'a> for File {
+    type Lock = BufReader<&'a mut Self>;
+
+    fn lock_reader<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
+        Ok(BufReader::new(self))
+    }
+
+    fn raw_object(&self) -> Option<RawObject> {
+        Some(RawObject(self.as_raw_handle()))
+    }
+}
+
+impl<'a> UtilRead<'a> for io::Stdin {
+    type Lock = io::StdinLock<'a>;
+
+    fn lock_reader<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
+        Ok(self.lock())
+    }
+
+    fn raw_object(&self) -> Option<RawObject> {
+        Some(RawObject(self.as_raw_handle()))
+    }
+}
+
+impl<'a> UtilWrite<'a> for File {
+    type Lock = BufWriter<&'a mut Self>;
+
+    fn lock_writer<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
+        Ok(BufWriter::new(self))
+    }
+
+    fn raw_object(&self) -> Option<RawObject> {
+        Some(RawObject(self.as_raw_handle()))
+    }
+}
+
+impl<'a> UtilWrite<'a> for io::Stdout {
+    type Lock = io::StdoutLock<'a>;
+
+    fn lock_writer<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
+        Ok(self.lock())
+    }
+
+    fn raw_object(&self) -> Option<RawObject> {
+        Some(RawObject(self.as_raw_handle()))
+    }
+}
+
+impl<'a> UtilWrite<'a> for io::Stderr {
+    type Lock = io::StderrLock<'a>;
+
+    fn lock_writer<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
+        Ok(self.lock())
+    }
+
+    fn raw_object(&self) -> Option<RawObject> {
+        Some(RawObject(self.as_raw_handle()))
+    }
+}

--- a/src/posix/cat/mod.rs
+++ b/src/posix/cat/mod.rs
@@ -477,7 +477,7 @@ where
 {
     let can_write_fast = options.can_write_fast();
     
-    let interactive = is_tty(setup.input().raw_fd());
+    let interactive = is_tty(setup.input().raw_object());
     // XXX: should current_dir() just return Option<Rc<Path>> or something similar to avoid the cloning?
     let curdir = setup.current_dir().map(|p| p.to_path_buf());
     let (input, output, error) = setup.stdio();

--- a/src/posix/cat/mod.rs
+++ b/src/posix/cat/mod.rs
@@ -41,8 +41,8 @@ use std::fs::{metadata, File};
 use std::iter;
 use std::io::{self, BufRead, Read, Write};
 use std::path::Path;
-use {UtilSetup, ArgsIter, LockError, UtilRead, UtilWrite, Result, is_tty};
-use util;
+use {UtilSetup, ArgsIter, LockError, UtilRead, UtilWrite, Result};
+use util::{self, is_tty};
 
 /// Unix domain socket support
 #[cfg(unix)]

--- a/src/posix/cat/mod.rs
+++ b/src/posix/cat/mod.rs
@@ -481,9 +481,9 @@ where
     // XXX: should current_dir() just return Option<Rc<Path>> or something similar to avoid the cloning?
     let curdir = setup.current_dir().map(|p| p.to_path_buf());
     let (input, output, error) = setup.stdio();
-    let stdin = input.lock_reader()?;
-    let stdout = output.lock_writer()?;
-    let stderr = error.lock_writer()?;
+    let stdin = input.lock()?;
+    let stdout = output.lock()?;
+    let stderr = error.lock()?;
 
     let mut util = Cat::new(stdin, stdout, stderr, curdir.as_ref().map(|p| p.as_path()), interactive);
 

--- a/src/posix/chmod/mod.rs
+++ b/src/posix/chmod/mod.rs
@@ -148,8 +148,8 @@ where
         recursive: recursive,
         fmode: fmode,
         cmode: matches.value_of("MODE"),
-        stdout: stdout.lock_writer()?,
-        stderr: stderr.lock_writer()?,
+        stdout: stdout.lock()?,
+        stderr: stderr.lock()?,
         current_dir: current_dir,
     };
 

--- a/src/posix/echo/mod.rs
+++ b/src/posix/echo/mod.rs
@@ -10,8 +10,9 @@ use {ArgsIter, Result, UtilSetup, UtilWrite};
 
 use std::ffi::OsStr;
 use std::io::Write;
-use std::os::unix::ffi::OsStrExt;
 use std::str;
+
+use util::OsStrExt;
 
 #[allow(unused)]
 pub(crate) const NAME: &str = "echo";
@@ -56,7 +57,7 @@ where
 fn write_str<W: Write>(output: &mut W, s: &OsStr) -> Result<bool> {
     let mut found_c = false;
 
-    let mut iter = s.as_bytes().iter();
+    let mut iter = s.try_as_bytes()?.iter();
     while let Some(&byte) = iter.next() {
         let out_byte = match byte {
             b'\\' => match iter.next() {

--- a/src/posix/echo/mod.rs
+++ b/src/posix/echo/mod.rs
@@ -27,7 +27,7 @@ where
     args.next();
 
     let output = setup.output();
-    let mut output = output.lock_writer()?;
+    let mut output = output.lock()?;
 
     let mut print_newline = true;
 

--- a/src/posix/head/mod.rs
+++ b/src/posix/head/mod.rs
@@ -123,10 +123,10 @@ where
     let current_dir = setup.current_dir().map(|p| p.to_owned());
     let (input, output, error) = setup.stdio();
 
-    let mut output = output.lock_writer()?;
+    let mut output = output.lock()?;
     if matches.is_present("FILES") {
         let mut result = Ok(());
-        let mut err_stream = error.lock_writer()?;
+        let mut err_stream = error.lock()?;
 
         let file_count = matches.occurrences_of("FILES");
 
@@ -167,7 +167,7 @@ where
     I: for<'a> UtilRead<'a>,
     O: Write,
 {
-    let stdin = stdin.lock_reader()?;
+    let stdin = stdin.lock()?;
     handle_data(output, stdin, filename, options)
 }
 

--- a/src/posix/sh/ast.rs
+++ b/src/posix/sh/ast.rs
@@ -18,7 +18,7 @@ use std::process;
 use std::rc::Rc;
 use std::result::Result as StdResult;
 
-use util::RawFdWrapper;
+use util::RawObjectWrapper;
 use super::{NAME, UtilSetup};
 use super::command::{CommandEnv, CommandEnvContainer, CommandWrapper, ExecData, ExecEnv, InProcessCommand, InProcessChild, ShellChild};
 use super::env::{CheckBreak, EnvFd, Environment, TryClone};
@@ -1233,7 +1233,7 @@ impl CommandSubst {
         };
 
         let code = fake_subshell(data, |data| {
-            data.env.set_local_fd(1, EnvFd::Fd(RawFdWrapper::new(write, false, true)));
+            data.env.set_local_fd(1, EnvFd::Fd(RawObjectWrapper::new(write, false, true)));
             self.command.execute(data)
         });
         data.env.special_vars().set_last_exitcode(code);
@@ -1243,7 +1243,7 @@ impl CommandSubst {
 
         // read the output from the pipe into a vector
         let mut output = vec![];
-        let res = self.write_error(data.setup, data.env, RawFdWrapper::new(read, true, false).read_to_end(&mut output));
+        let res = self.write_error(data.setup, data.env, RawObjectWrapper::new(read, true, false).read_to_end(&mut output));
 
         // XXX: not sure if we want to just ignore these so let them create warnings for now
         unistd::close(read);

--- a/src/posix/sh/builtin/cd.rs
+++ b/src/posix/sh/builtin/cd.rs
@@ -79,7 +79,7 @@ impl BuiltinSetup for CdBuiltin {
             if should_print {
                 // XXX: ignore errors?
                 let output = setup.output();
-                if let Ok(mut output) = output.lock_writer() {
+                if let Ok(mut output) = output.lock() {
                     let _ = output.write_all(env.get_var("PWD").unwrap().as_bytes());
                     let _ = writeln!(output);
                 }

--- a/src/posix/sh/builtin/exec.rs
+++ b/src/posix/sh/builtin/exec.rs
@@ -34,15 +34,15 @@ impl BuiltinSetup for ExecBuiltin {
             // NOTE: we need to duplicate the fds as from_raw_fd() takes ownership
             // TODO: this needs to duplicate all the fds (3-9 because stdin/stdout/stderr are done
             //       already below) like in command.rs
-            if let Some(fd) = setup.input().raw_fd() {
+            if let Some(fd) = setup.input().raw_object() {
                 let fd = unistd::dup(fd)?;
                 cmd.stdin(unsafe { Stdio::from_raw_fd(fd) });
             }
-            if let Some(fd) = setup.output().raw_fd() {
+            if let Some(fd) = setup.output().raw_object() {
                 let fd = unistd::dup(fd)?;
                 cmd.stdout(unsafe { Stdio::from_raw_fd(fd) });
             }
-            if let Some(fd) = setup.error().raw_fd() {
+            if let Some(fd) = setup.error().raw_object() {
                 let fd = unistd::dup(fd)?;
                 cmd.stderr(unsafe { Stdio::from_raw_fd(fd) });
             }

--- a/src/posix/sh/builtin/mod.rs
+++ b/src/posix/sh/builtin/mod.rs
@@ -165,9 +165,9 @@ impl Builtin {
         //        would not have to do this (as obviously static dispatch is faster)
         // TODO: add anything else in data to setup
         // TODO: add export_vars to setup
-        let input_fd = input.raw_fd();
-        let output_fd = output.raw_fd();
-        let error_fd = error.raw_fd();
+        let input_fd = input.raw_object();
+        let output_fd = output.raw_object();
+        let error_fd = error.raw_object();
 
         let mut input = UtilReadDyn::new(Box::new(input), input_fd);
         let mut output = UtilWriteDyn::new(Box::new(output), output_fd);

--- a/src/posix/sh/builtin/mod.rs
+++ b/src/posix/sh/builtin/mod.rs
@@ -8,9 +8,10 @@ use util::{ReadableVec, UtilReadDyn, UtilWriteDyn};
 use super::UtilSetup;
 use super::ast::{ExitCode, RuntimeData};
 use super::command::{ExecData, InProcessChild, InProcessCommand, ShellChild};
-use super::env::{CheckBreak, EnvFd, Environment, TryClone};
+use super::env::{CheckBreak, EnvFd, Environment};
 use super::error::{CmdResult, BuiltinError, CommandError};
 use super::option::ShellOption;
+use super::types::TryClone;
 
 use self::break_builtin::BreakBuiltin;
 use self::cd::CdBuiltin;
@@ -98,7 +99,7 @@ impl Builtin {
     {
         use self::EnvFd::*;
 
-        match env.get_fd(1).current_val().try_clone()? {
+        match env.get_fd(1).try_clone()? {
             File(file) => self.execute_stdout(env, data, input, file),
             Fd(fd) | ChildStdout(fd) => self.execute_stdout(env, data, input, fd),
             Pipe(pipe) => self.execute_stdout(env, data, input, pipe.raw_object_wrapper()),
@@ -116,7 +117,7 @@ impl Builtin {
     {
         use self::EnvFd::*;
 
-        match env.get_fd(2).current_val().try_clone()? {
+        match env.get_fd(2).try_clone()? {
             File(file) => self.execute_stderr(env, data, input, output, file),
             Fd(fd) | ChildStdout(fd) => self.execute_stderr(env, data, input, output, fd),
             Pipe(pipe) => self.execute_stderr(env, data, input, output, pipe.raw_object_wrapper()),
@@ -188,7 +189,7 @@ impl InProcessCommand for Builtin {
     fn execute<'a: 'b, 'b, S: UtilSetup + 'a>(&self, rt_data: &mut RuntimeData<'a, 'b, S>, data: ExecData) -> CmdResult<ExitCode> {
         use self::EnvFd::*;
 
-        let res = match rt_data.env.get_fd(0).current_val().try_clone()? {
+        let res = match rt_data.env.get_fd(0).try_clone()? {
             File(file) => self.execute_stdin(rt_data.env, data, file),
             Fd(fd) | ChildStdout(fd) => self.execute_stdin(rt_data.env, data, fd),
             Pipe(pipe) => self.execute_stdin(rt_data.env, data, pipe.raw_object_wrapper()),

--- a/src/posix/sh/builtin/mod.rs
+++ b/src/posix/sh/builtin/mod.rs
@@ -101,6 +101,7 @@ impl Builtin {
         match env.get_fd(1).current_val().try_clone()? {
             File(file) => self.execute_stdout(env, data, input, file),
             Fd(fd) | ChildStdout(fd) => self.execute_stdout(env, data, input, fd),
+            Pipe(pipe) => self.execute_stdout(env, data, input, pipe.raw_object_wrapper()),
             // FIXME: this won't work correctly
             Piped(piped) => self.execute_stdout(env, data, input, piped),
             Null => self.execute_stdout(env, data, input, io::sink()),
@@ -118,6 +119,7 @@ impl Builtin {
         match env.get_fd(2).current_val().try_clone()? {
             File(file) => self.execute_stderr(env, data, input, output, file),
             Fd(fd) | ChildStdout(fd) => self.execute_stderr(env, data, input, output, fd),
+            Pipe(pipe) => self.execute_stderr(env, data, input, output, pipe.raw_object_wrapper()),
             // FIXME: this won't work correctly
             Piped(piped) => self.execute_stderr(env, data, input, output, piped),
             Null => self.execute_stderr(env, data, input, output, io::sink()),
@@ -189,6 +191,7 @@ impl InProcessCommand for Builtin {
         let res = match rt_data.env.get_fd(0).current_val().try_clone()? {
             File(file) => self.execute_stdin(rt_data.env, data, file),
             Fd(fd) | ChildStdout(fd) => self.execute_stdin(rt_data.env, data, fd),
+            Pipe(pipe) => self.execute_stdin(rt_data.env, data, pipe.raw_object_wrapper()),
             Piped(piped) => self.execute_stdin(rt_data.env, data, ReadableVec(piped)),
             Null => self.execute_stdin(rt_data.env, data, io::empty()),
             _ => unimplemented!(),

--- a/src/posix/sh/builtin/read.rs
+++ b/src/posix/sh/builtin/read.rs
@@ -28,7 +28,7 @@ impl BuiltinSetup for ReadBuiltin {
             .get_matches_from_safe(data.args)?;
 
         let input = setup.input();
-        let mut input = input.lock_reader()?;
+        let mut input = input.lock()?;
 
         let ignore_backslash = matches.is_present("backslash");
 

--- a/src/posix/sh/env.rs
+++ b/src/posix/sh/env.rs
@@ -14,7 +14,7 @@ use super::error::CommandError;
 use super::ast::{ExitCode, FunctionBody};
 use super::builtin::{Builtin, BuiltinSet};
 use super::option::FD_COUNT;
-use util::RawFdWrapper;
+use util::RawObjectWrapper;
 
 pub trait TryClone: Sized {
     fn try_clone(&self) -> Result<Self, CommandError>;
@@ -32,9 +32,9 @@ pub enum EnvFd {
     Null,
     Piped(Vec<u8>),
     File(File),
-    Fd(RawFdWrapper),
+    Fd(RawObjectWrapper),
     Pipeline,
-    ChildStdout(RawFdWrapper),
+    ChildStdout(RawObjectWrapper),
 }
 
 impl EnvFd {
@@ -62,7 +62,7 @@ impl TryClone for EnvFd {
             EnvFd::File(file) => {
                 // XXX: maybe just convert into Fd?
                 let fd = file.as_raw_fd();
-                let new_fd = RawFdWrapper::new(fd, false, false).dup_sh().map_err(|e| CommandError::DupFd { fd: fd, err: e })?;
+                let new_fd = RawObjectWrapper::new(fd, false, false).dup_sh().map_err(|e| CommandError::DupFd { fd: fd, err: e })?;
                 let new_file = unsafe { File::from_raw_fd(new_fd) };
                 EnvFd::File(new_file)
             }
@@ -75,7 +75,7 @@ impl TryClone for EnvFd {
 
     /*pub fn create_pipe() -> Result<Self, CommandError> {
         let (read, write) = unistd::pipe().map_err(|e| CommandError::Pipe(e))?;
-        Ok(EnvFd::Pipeline(RawFdWrapper::new(read, true, false), RawFdWrapper::new(write, false, true)))
+        Ok(EnvFd::Pipeline(RawObjectWrapper::new(read, true, false), RawObjectWrapper::new(write, false, true)))
     }*/
 }
 

--- a/src/posix/sh/error.rs
+++ b/src/posix/sh/error.rs
@@ -39,7 +39,7 @@ pub enum CommandError {
 
     #[fail(display = "could not duplicate fd {}: {}", fd, err)]
     DupFd {
-        #[cause] err: nix::Error,
+        #[cause] err: io::Error,
         fd: RawFd,
     },
 

--- a/src/posix/sh/error.rs
+++ b/src/posix/sh/error.rs
@@ -47,10 +47,7 @@ pub enum CommandError {
     InvalidFd(u8),
 
     #[fail(display = "{}", _0)]
-    Pipe(#[cause] nix::Error),
-
-    #[fail(display = "{}", _0)]
-    PipeIo(#[cause] io::Error),
+    Pipe(#[cause] io::Error),
 
     #[fail(display = "could not fork: {}", _0)]
     Fork(#[cause] nix::Error),

--- a/src/posix/sh/mod.rs
+++ b/src/posix/sh/mod.rs
@@ -18,6 +18,7 @@ mod env;
 mod error;
 pub mod option;
 mod parser;
+mod types;
 
 pub const NAME: &str = "sh";
 pub const DESCRIPTION: &str = "Minimal POSIX shell";
@@ -244,9 +245,9 @@ where
     // although HOME and PATH and stuff are used, we shouldn't set them explicitly
 
     // FIXME: what to do if can't create fd? (such as in testing framework)
-    env.set_global_fd(0, EnvFd::Fd(RawObjectWrapper::try_from(setup.input().raw_object().unwrap())?));
-    env.set_global_fd(1, EnvFd::Fd(RawObjectWrapper::try_from(setup.output().raw_object().unwrap())?));
-    env.set_global_fd(2, EnvFd::Fd(RawObjectWrapper::try_from(setup.error().raw_object().unwrap())?));
+    env.set_fd(0, EnvFd::Fd(RawObjectWrapper::try_from(setup.input().raw_object().unwrap())?));
+    env.set_fd(1, EnvFd::Fd(RawObjectWrapper::try_from(setup.output().raw_object().unwrap())?));
+    env.set_fd(2, EnvFd::Fd(RawObjectWrapper::try_from(setup.error().raw_object().unwrap())?));
 
     Ok(())
 }

--- a/src/posix/sh/mod.rs
+++ b/src/posix/sh/mod.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 use std::ffi::{OsStr, OsString};
 
 use {UtilRead, UtilWrite, UtilSetup, ArgsIter, Result};
-use util::RawFdWrapper;
+use util::RawObjectWrapper;
 
 use self::env::{EnvFd, Environment};
 use self::parser::Parser;
@@ -244,9 +244,9 @@ where
     // although HOME and PATH and stuff are used, we shouldn't set them explicitly
 
     // FIXME: what to do if can't create fd? (such as in testing framework)
-    env.set_global_fd(0, EnvFd::Fd(RawFdWrapper::try_from(setup.input().raw_fd().unwrap())?));
-    env.set_global_fd(1, EnvFd::Fd(RawFdWrapper::try_from(setup.output().raw_fd().unwrap())?));
-    env.set_global_fd(2, EnvFd::Fd(RawFdWrapper::try_from(setup.error().raw_fd().unwrap())?));
+    env.set_global_fd(0, EnvFd::Fd(RawObjectWrapper::try_from(setup.input().raw_object().unwrap())?));
+    env.set_global_fd(1, EnvFd::Fd(RawObjectWrapper::try_from(setup.output().raw_object().unwrap())?));
+    env.set_global_fd(2, EnvFd::Fd(RawObjectWrapper::try_from(setup.error().raw_object().unwrap())?));
 
     Ok(())
 }

--- a/src/posix/sh/types/mod.rs
+++ b/src/posix/sh/types/mod.rs
@@ -1,0 +1,103 @@
+use std::mem;
+
+use super::error::CommandError;
+
+pub use self::scoped_map::ScopedMap;
+pub use self::scoped_array::{FdArray, ScopedArray};
+
+pub mod scoped_map;
+pub mod scoped_array;
+
+pub trait TryClone: Sized {
+    fn try_clone<'a>(&'a self) -> Result<Self, CommandError>;
+}
+
+/// Indicate that a type is scoped.  In this context, "scoped" means that upon calling
+/// `exit_scope()`, any values changed after calling `enter_scope()` will be reset to their
+/// original value.  For every call to `exit_scope()`, there must one corresponding call to
+/// `enter_scope()` that executes prior to the call to `exit_scope()`.  Both `enter_scope()` and
+/// `exit_scope()` can be called several times in a row (which indicates that multiple scopes have
+/// been entered/exited).
+pub trait Scoped {
+    /// Enter a scope, saving values in such a way that they will be restored upon a call to
+    /// `exit_scope()`.
+    fn enter_scope(&mut self);
+
+    /// Exit a scope, restoring all values saved upon the previous `enter_scope()` call.
+    fn exit_scope(&mut self);
+}
+
+// FIXME: locality design may be flawed as we need to set global scope (but only within the current
+//        subshell) in functions, whereas anything set in subshells needs to remain within that
+//        subshell.  not sure if the current setup is good enough (it might be okay if we only
+//        enter_scope() when entering a subshell, which i don't believe is what happens right now)
+// FIXME: should not be pub
+#[derive(Debug)]
+pub struct Locality<T> {
+    item: T,
+    count: usize,
+    parent: Option<Box<Locality<T>>>,
+}
+
+impl<T> Locality<T> {
+    pub fn new(item: T, count: usize, parent: Option<Box<Locality<T>>>) -> Self {
+        Self {
+            item,
+            count,
+            parent,
+        }
+    }
+
+    pub fn set_val(&mut self, value: T) {
+        if self.count == 0 {
+            self.item = value;
+        } else {
+            let cur_item = mem::replace(&mut self.item, value);
+            let count = mem::replace(&mut self.count, 0);
+            let prev_locality = mem::replace(&mut self.parent, None);
+            self.parent = Some(Box::new(Locality::new(cur_item, count - 1, prev_locality)));
+        }
+    }
+
+    pub fn current_val(&self) -> &T {
+        &self.item
+    }
+
+    pub fn current_val_mut(&mut self) -> &mut T {
+        &mut self.item
+    }
+
+    pub fn outer_scope(&self) -> Option<&Self> {
+        self.parent.as_ref().map(|val| &**val)
+    }
+}
+
+impl<T> Scoped for Locality<T> {
+    fn enter_scope(&mut self) {
+        self.count += 1;
+    }
+
+    fn exit_scope(&mut self) {
+        let parent = if self.count == 0 {
+            mem::replace(&mut self.parent, None)
+        } else {
+            self.count -= 1;
+            return;
+        };
+
+        // NOTE: this should be fine as exit_scope() should not be called in the base scope
+        mem::replace(self, *parent.unwrap());
+    }
+}
+
+impl<T: Default> Default for Locality<T> {
+    fn default() -> Self {
+        Locality::new(T::default(), 0, None)
+    }
+}
+
+impl<T: Clone> Clone for Locality<T> {
+    fn clone(&self) -> Self {
+        Locality::new(self.item.clone(), self.count, self.parent.clone())
+    }
+}

--- a/src/posix/sh/types/scoped_array.rs
+++ b/src/posix/sh/types/scoped_array.rs
@@ -1,0 +1,155 @@
+use std::iter::IntoIterator;
+use std::slice;
+use std::ops::{Index, IndexMut};
+
+use super::{Locality, Scoped};
+
+use posix::sh::env::EnvFd;
+use posix::sh::option::FD_COUNT;
+
+pub type FdArray = ScopedArray<[Locality<EnvFd>; FD_COUNT], EnvFd>;
+
+/// An array meant to abstract the implementation of variable (or, more accurately, file
+/// descriptor) scoping (e.g. for subshells) so that the underlying implementation can be easily
+/// changed.  The current design is (in some ways) similar to
+/// [arrayvec](https://crates.io/crates/arrayvec), but less general.
+#[derive(Debug, Default)]
+pub struct ScopedArray<T: FixedArray<Item = Locality<V>>, V> {
+    inner: T,
+}
+
+impl<T: FixedArray<Item = Locality<V>>, V> ScopedArray<T, V> {
+    pub fn set_val(&mut self, idx: usize, val: V) {
+        self.inner.as_mut()[idx].set_val(val);
+    }
+}
+
+// XXX: do we really want to implement this?  this allows stuff like arr[idx] = val to work, which
+//      will end up ignoring Locality::set_val()
+impl<T: FixedArray<Item = Locality<V>>, V> ScopedArray<T, V> {
+    pub fn iter_mut(&mut self) -> ScopedArrayIter<V> {
+        ScopedArrayIter { inner: self.inner.iter_mut() }
+    }
+}
+
+impl<T: FixedArray<Item = Locality<V>>, V> Scoped for ScopedArray<T, V> {
+    fn enter_scope(&mut self) {
+        for var in self.inner.iter_mut() {
+            var.enter_scope();
+        }
+    }
+
+    fn exit_scope(&mut self) {
+        for var in self.inner.iter_mut() {
+            var.exit_scope();
+        }
+    }
+}
+
+impl<'a, T: FixedArray<Item = Locality<V>>, V> IntoIterator for &'a mut ScopedArray<T, V> {
+    type Item = &'a mut V;
+    type IntoIter = ScopedArrayIter<'a, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
+impl<T: FixedArray<Item = Locality<V>>, V> Index<usize> for ScopedArray<T, V> {
+    type Output = V;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        self.inner.as_slice()[index].current_val()
+    }
+}
+
+impl<T: FixedArray<Item = Locality<V>>, V> IndexMut<usize> for ScopedArray<T, V> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        self.inner.as_mut()[index].current_val_mut()
+    }
+}
+
+pub struct ScopedArrayIter<'a, V: 'a> {
+    inner: IterMut<'a, Locality<V>>,
+}
+
+impl<'a, V: 'a> Iterator for ScopedArrayIter<'a, V> {
+    type Item = &'a mut V;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|v| v.current_val_mut())
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+pub trait FixedArray {
+    type Item;
+
+    fn as_slice(&self) -> &[Self::Item];
+
+    // FIXME: should implement AsMut<[Self::Item]> instead of this
+    fn as_mut(&mut self) -> &mut [Self::Item];
+
+    fn iter<'a>(&'a self) -> Iter<'a, Self::Item> {
+        Iter { inner: self.as_slice().iter() }
+    }
+
+    fn iter_mut<'a>(&'a mut self) -> IterMut<'a, Self::Item>;   
+}
+
+pub struct Iter<'a, T: 'a> {
+    inner: slice::Iter<'a, T>,
+}
+
+impl<'a, T: 'a> Iterator for Iter<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+pub struct IterMut<'a, T: 'a> {
+    inner: slice::IterMut<'a, T>,
+}
+
+impl<'a, T: 'a> Iterator for IterMut<'a, T> {
+    type Item = &'a mut T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+macro_rules! impl_fixed {
+    ($elems:expr) => {
+        impl<T> FixedArray for [T; $elems] {
+            type Item = T;
+
+            fn as_slice(&self) -> &[T] {
+                &self[..]
+            }
+
+            fn as_mut(&mut self) -> &mut [T] {
+                &mut self[..]
+            }
+
+            fn iter_mut<'a>(&'a mut self) -> IterMut<'a, Self::Item> {
+                IterMut { inner: (self as &mut [T]).as_mut().iter_mut() }
+            }
+        }
+    }
+}
+
+impl_fixed!(FD_COUNT);

--- a/src/posix/sh/types/scoped_map.rs
+++ b/src/posix/sh/types/scoped_map.rs
@@ -1,0 +1,156 @@
+use std::borrow::Borrow;
+use std::collections::hash_map::{self, Entry, HashMap, RandomState};
+use std::fmt::{self, Debug};
+use std::hash::{BuildHasher, Hash};
+use std::iter::FromIterator;
+use std::mem;
+
+use super::{Locality, Scoped};
+
+/// A map meant to abstract the implementation of variable scoping (e.g. for subshells) so that the
+/// underlying implementation can be easily changed.
+pub struct ScopedMap<K, V, S = RandomState> {
+    // XXX: ideally, we would have our own hashmap implementation that hashes the key once and then
+    //      uses the hashed key to check a hashmaps each representing their own scope for the
+    //      desired variable (of course checking from the innermost scope first).
+    maps: Locality<HashMap<K, Option<V>, S>>,
+}
+
+impl<K: Hash + Eq, V> ScopedMap<K, V, RandomState> {
+    pub fn new() -> Self {
+        ScopedMap::with_hasher(RandomState::new())
+    }
+}
+
+impl<K: Hash + Eq, V, S: BuildHasher + Default> ScopedMap<K, V, S> {
+    pub fn with_hasher(hash_builder: S) -> Self {
+        Self {
+            maps: Locality::new(HashMap::with_hasher(hash_builder), 0, None),
+        }
+    }
+
+    pub fn contains_key<Q: ?Sized>(&self, k: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        self.get(k).is_some()
+    }
+
+    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        let mut locality = Some(&self.maps);
+        while let Some(scope) = locality {
+            if let Some(val) = scope.current_val().get(k) {
+                return val.as_ref();
+            }
+            locality = scope.outer_scope();
+        }
+        None
+    }
+
+    pub fn get_mut<Q: ?Sized>(&mut self, k: &Q) -> Option<&mut V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        self.maps.current_val_mut().get_mut(k).and_then(|v| v.as_mut())
+    }
+
+    pub fn remove<'a, Q: ?Sized>(&mut self, k: &'a Q) -> Option<V>
+    where
+        K: Borrow<Q> + From<&'a Q>,
+        Q: Hash + Eq,
+    {
+        // XXX: we always allocate here for now, but implementing our own hashmap will hopefully
+        //      allow us to only allocate when absolutely necessary
+        match self.maps.current_val_mut().entry(k.into()) {
+            Entry::Occupied(mut entry) => mem::replace(entry.get_mut(), None),
+            Entry::Vacant(entry) => {
+                entry.insert(None);
+                None
+            }
+        }
+    }
+
+    pub fn insert(&mut self, key: K, val: V) -> Option<V> {
+        if self.maps.count > 0 {
+            self.maps.set_val(HashMap::default());
+        }
+        self.maps.current_val_mut().insert(key, Some(val)).unwrap_or(None)
+    }
+
+    // FIXME: no idea how to do this quickly
+    pub fn iter<'a>(&'a self) -> Iter<'a, K, V, S> {
+        Iter { maps: &self.maps, inner_iter: self.maps.current_val().iter(), found: vec![] }
+    }
+}
+
+impl<K: Eq + Hash, V, S: BuildHasher + Default> ScopedMap<K, V, S> {
+    fn default() -> Self {
+        Self {
+            maps: Default::default(),
+        }
+    }
+}
+
+impl<K, V, S> Scoped for ScopedMap<K, V, S> {
+    fn enter_scope(&mut self) {
+        self.maps.enter_scope();
+    }
+
+    fn exit_scope(&mut self) {
+        self.maps.exit_scope();
+    }
+}
+
+impl<K: Eq + Hash, V, S: BuildHasher + Default> FromIterator<(K, V)> for ScopedMap<K, V, S> {
+    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
+        let map = iter.into_iter().map(|(k, v)| (k, Some(v))).collect();
+        ScopedMap {
+            maps: Locality::new(map, 0, None),
+        }
+    }
+}
+
+impl<K: Eq + Hash + Debug, V: Debug, S: BuildHasher> Debug for ScopedMap<K, V, S> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.maps.fmt(f)
+    }
+}
+
+pub struct Iter<'a, K: Hash + Eq + 'a, V: 'a, S: BuildHasher + 'a> {
+    maps: &'a Locality<HashMap<K, Option<V>, S>>,
+    inner_iter: hash_map::Iter<'a, K, Option<V>>,
+
+    // FIXME: we ideally shouldn't need to allocate here (it's probably easiest to fix this using
+    //        a custom hashmap)
+    found: Vec<&'a K>,
+}
+
+impl<'a, K: Hash + Eq + 'a, V: 'a, S: BuildHasher + 'a> Iterator for Iter<'a, K, V, S> {
+    type Item = (&'a K, &'a V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some((key, Some(value))) = self.inner_iter.next() {
+            if !self.found.contains(&key) {
+                self.found.push(key);
+                return Some((key, value));
+            }
+        }
+        if let Some(scope) = self.maps.outer_scope() {
+            self.maps = scope;
+            self.inner_iter = self.maps.current_val().iter();
+            self.next()
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner_iter.size_hint()
+    }
+}

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,6 +1,7 @@
 use super::{LockError, LockableRead, LockableWrite, UtilRead, UtilWrite};
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, BufWriter, Empty, Sink, Write};
+use std::net::TcpStream;
 use std::result::Result as StdResult;
 use util::{AsRawObject, RawObject, RawObjectWrapper, ReadableVec, UtilReadDyn, UtilWriteDyn};
 
@@ -183,6 +184,30 @@ impl<'a> UtilWrite<'a> for io::Stderr {
 
     fn lock_writer<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
         Ok(self.lock())
+    }
+
+    fn raw_object(&self) -> Option<RawObject> {
+        Some(self.as_raw_object())
+    }
+}
+
+impl<'a> UtilRead<'a> for TcpStream {
+    type Lock = BufReader<&'a mut Self>;
+
+    fn lock_reader<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
+        Ok(BufReader::new(self))
+    }
+
+    fn raw_object(&self) -> Option<RawObject> {
+        Some(self.as_raw_object())
+    }
+}
+
+impl<'a> UtilWrite<'a> for TcpStream {
+    type Lock = BufWriter<&'a mut Self>;
+
+    fn lock_writer<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
+        Ok(BufWriter::new(self))
     }
 
     fn raw_object(&self) -> Option<RawObject> {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -8,8 +8,8 @@ use util::{AsRawObject, RawObject, RawObjectWrapper, ReadableVec, UtilReadDyn, U
 impl<'a, 'b, T: UtilRead<'a>> UtilRead<'a> for &'b mut T {
     type Lock = T::Lock;
 
-    fn lock_reader<'c: 'a>(&'c mut self) -> StdResult<Self::Lock, LockError> {
-        (**self).lock_reader()
+    fn lock<'c: 'a>(&'c mut self) -> StdResult<Self::Lock, LockError> {
+        (**self).lock()
     }
 
     fn raw_object(&self) -> Option<RawObject> {
@@ -20,8 +20,8 @@ impl<'a, 'b, T: UtilRead<'a>> UtilRead<'a> for &'b mut T {
 impl<'a, 'b, T: UtilWrite<'a>> UtilWrite<'a> for &'b mut T {
     type Lock = T::Lock;
 
-    fn lock_writer<'c: 'a>(&'c mut self) -> StdResult<Self::Lock, LockError> {
-        (**self).lock_writer()
+    fn lock<'c: 'a>(&'c mut self) -> StdResult<Self::Lock, LockError> {
+        (**self).lock()
     }
 
     fn raw_object(&self) -> Option<RawObject> {
@@ -30,22 +30,22 @@ impl<'a, 'b, T: UtilWrite<'a>> UtilWrite<'a> for &'b mut T {
 }
 
 impl<'a, T: UtilRead<'a>> LockableRead<'a> for T {
-    fn lock_reader_dyn<'b: 'a>(&'b mut self) -> StdResult<Box<BufRead + 'a>, LockError> {
-        self.lock_reader().map(|v| Box::new(v) as Box<BufRead + 'a>)
+    fn lock_dyn<'b: 'a>(&'b mut self) -> StdResult<Box<BufRead + 'a>, LockError> {
+        self.lock().map(|v| Box::new(v) as Box<BufRead + 'a>)
     }
 }
 
 impl<'a, T: UtilWrite<'a>> LockableWrite<'a> for T {
-    fn lock_writer_dyn<'b: 'a>(&'b mut self) -> StdResult<Box<Write + 'a>, LockError> {
-        self.lock_writer().map(|v| Box::new(v) as Box<Write + 'a>)
+    fn lock_dyn<'b: 'a>(&'b mut self) -> StdResult<Box<Write + 'a>, LockError> {
+        self.lock().map(|v| Box::new(v) as Box<Write + 'a>)
     }
 }
 
 impl<'a> UtilRead<'a> for UtilReadDyn {
     type Lock = Box<BufRead + 'a>;
 
-    fn lock_reader<'c: 'a>(&'c mut self) -> StdResult<Self::Lock, LockError> {
-        self.inner.lock_reader_dyn() as StdResult<Box<BufRead + 'a>, LockError>
+    fn lock<'c: 'a>(&'c mut self) -> StdResult<Self::Lock, LockError> {
+        self.inner.lock_dyn() as StdResult<Box<BufRead + 'a>, LockError>
     }
 
     fn raw_object(&self) -> Option<RawObject> {
@@ -56,8 +56,8 @@ impl<'a> UtilRead<'a> for UtilReadDyn {
 impl<'a> UtilWrite<'a> for UtilWriteDyn {
     type Lock = Box<Write + 'a>;
 
-    fn lock_writer<'b: 'a>(&'b mut self) -> StdResult<Self::Lock, LockError> {
-        self.inner.lock_writer_dyn()
+    fn lock<'b: 'a>(&'b mut self) -> StdResult<Self::Lock, LockError> {
+        self.inner.lock_dyn()
     }
 
     fn raw_object(&self) -> Option<RawObject> {
@@ -70,7 +70,7 @@ impl<'a> UtilWrite<'a> for UtilWriteDyn {
 impl<'a, 'b> UtilRead<'a> for &'b [u8] {
     type Lock = &'a [u8];
 
-    fn lock_reader<'c: 'a>(&'c mut self) -> StdResult<Self::Lock, LockError> {
+    fn lock<'c: 'a>(&'c mut self) -> StdResult<Self::Lock, LockError> {
         Ok(self)
     }
 }
@@ -78,7 +78,7 @@ impl<'a, 'b> UtilRead<'a> for &'b [u8] {
 impl<'a> UtilRead<'a> for ReadableVec<u8> {
     type Lock = &'a [u8];
 
-    fn lock_reader<'b: 'a>(&'b mut self) -> StdResult<Self::Lock, LockError> {
+    fn lock<'b: 'a>(&'b mut self) -> StdResult<Self::Lock, LockError> {
         Ok(&self.0)
     }
 }
@@ -86,7 +86,7 @@ impl<'a> UtilRead<'a> for ReadableVec<u8> {
 impl<'a> UtilWrite<'a> for Vec<u8> {
     type Lock = &'a mut Self;
 
-    fn lock_writer<'b: 'a>(&'b mut self) -> StdResult<Self::Lock, LockError> {
+    fn lock<'b: 'a>(&'b mut self) -> StdResult<Self::Lock, LockError> {
         Ok(self)
     }
 }
@@ -94,7 +94,7 @@ impl<'a> UtilWrite<'a> for Vec<u8> {
 impl<'a> UtilRead<'a> for RawObjectWrapper {
     type Lock = BufReader<&'a mut Self>;
 
-    fn lock_reader<'b: 'a>(&'b mut self) -> StdResult<Self::Lock, LockError> {
+    fn lock<'b: 'a>(&'b mut self) -> StdResult<Self::Lock, LockError> {
         Ok(BufReader::new(self))
     }
 
@@ -106,7 +106,7 @@ impl<'a> UtilRead<'a> for RawObjectWrapper {
 impl<'a> UtilWrite<'a> for RawObjectWrapper {
     type Lock = BufWriter<&'a mut Self>;
 
-    fn lock_writer<'b: 'a>(&'b mut self) -> StdResult<Self::Lock, LockError> {
+    fn lock<'b: 'a>(&'b mut self) -> StdResult<Self::Lock, LockError> {
         Ok(BufWriter::new(self))
     }
 
@@ -118,7 +118,7 @@ impl<'a> UtilWrite<'a> for RawObjectWrapper {
 impl<'a> UtilRead<'a> for Empty {
     type Lock = &'a mut Empty;
 
-    fn lock_reader<'b: 'a>(&'b mut self) -> StdResult<Self::Lock, LockError> {
+    fn lock<'b: 'a>(&'b mut self) -> StdResult<Self::Lock, LockError> {
         Ok(self)
     }
 }
@@ -126,7 +126,7 @@ impl<'a> UtilRead<'a> for Empty {
 impl<'a> UtilWrite<'a> for Sink {
     type Lock = &'a mut Sink;
 
-    fn lock_writer<'b: 'a>(&'b mut self) -> StdResult<Self::Lock, LockError> {
+    fn lock<'b: 'a>(&'b mut self) -> StdResult<Self::Lock, LockError> {
         Ok(self)
     }
 }
@@ -134,7 +134,7 @@ impl<'a> UtilWrite<'a> for Sink {
 impl<'a> UtilRead<'a> for File {
     type Lock = BufReader<&'a mut Self>;
 
-    fn lock_reader<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
+    fn lock<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
         Ok(BufReader::new(self))
     }
 
@@ -146,8 +146,8 @@ impl<'a> UtilRead<'a> for File {
 impl<'a> UtilRead<'a> for io::Stdin {
     type Lock = io::StdinLock<'a>;
 
-    fn lock_reader<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
-        Ok(self.lock())
+    fn lock<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
+        Ok(io::Stdin::lock(self))
     }
 
     fn raw_object(&self) -> Option<RawObject> {
@@ -158,7 +158,7 @@ impl<'a> UtilRead<'a> for io::Stdin {
 impl<'a> UtilWrite<'a> for File {
     type Lock = BufWriter<&'a mut Self>;
 
-    fn lock_writer<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
+    fn lock<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
         Ok(BufWriter::new(self))
     }
 
@@ -170,8 +170,8 @@ impl<'a> UtilWrite<'a> for File {
 impl<'a> UtilWrite<'a> for io::Stdout {
     type Lock = io::StdoutLock<'a>;
 
-    fn lock_writer<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
-        Ok(self.lock())
+    fn lock<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
+        Ok(io::Stdout::lock(self))
     }
 
     fn raw_object(&self) -> Option<RawObject> {
@@ -182,8 +182,8 @@ impl<'a> UtilWrite<'a> for io::Stdout {
 impl<'a> UtilWrite<'a> for io::Stderr {
     type Lock = io::StderrLock<'a>;
 
-    fn lock_writer<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
-        Ok(self.lock())
+    fn lock<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
+        Ok(io::Stderr::lock(self))
     }
 
     fn raw_object(&self) -> Option<RawObject> {
@@ -194,7 +194,7 @@ impl<'a> UtilWrite<'a> for io::Stderr {
 impl<'a> UtilRead<'a> for TcpStream {
     type Lock = BufReader<&'a mut Self>;
 
-    fn lock_reader<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
+    fn lock<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
         Ok(BufReader::new(self))
     }
 
@@ -206,7 +206,7 @@ impl<'a> UtilRead<'a> for TcpStream {
 impl<'a> UtilWrite<'a> for TcpStream {
     type Lock = BufWriter<&'a mut Self>;
 
-    fn lock_writer<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
+    fn lock<'b: 'a>(&'b mut self) -> Result<Self::Lock, LockError> {
         Ok(BufWriter::new(self))
     }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,6 +1,5 @@
 use super::{LockError, LockableRead, LockableWrite, UtilRead, UtilWrite};
-use std::fs::File;
-use std::io::{self, BufRead, BufReader, BufWriter, Empty, Sink, Write};
+use std::io::{BufRead, BufReader, BufWriter, Empty, Sink, Write};
 use std::result::Result as StdResult;
 use util::{RawObject, RawObjectWrapper, ReadableVec, UtilReadDyn, UtilWriteDyn};
 

--- a/src/sysinit/init/mod.rs
+++ b/src/sysinit/init/mod.rs
@@ -328,9 +328,9 @@ where
     }
 
     let (stdin, stdout, stderr) = setup.stdio();
-    let mut stdin = stdin.lock_reader()?;
-    let mut stdout = stdout.lock_writer()?;
-    let mut stderr = stderr.lock_writer()?;
+    let mut stdin = stdin.lock()?;
+    let mut stdout = stdout.lock()?;
+    let mut stderr = stderr.lock()?;
 
     display_msg!(stdout, "starting")?;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,7 +6,7 @@
 // For a copy, see the LICENSE file.
 //
 
-pub(crate) use super::{RawObject, RawObjectWrapper, OsStrExt, is_tty};
+pub(crate) use super::{AsRawObject, RawObject, RawObjectWrapper, Pipe, OsStrExt, is_tty};
 use super::{LockableRead, LockableWrite, MesaError, Result};
 
 use failure;

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,7 +6,7 @@
 // For a copy, see the LICENSE file.
 //
 
-pub(crate) use super::{AsRawObject, RawObject, RawObjectWrapper, Pipe, OsStrExt, is_tty};
+pub(crate) use super::{is_tty, AsRawObject, OsStrExt, Pipe, RawObject, RawObjectWrapper};
 use super::{LockableRead, LockableWrite, MesaError, Result};
 
 use failure;

--- a/tests/posix/cat.rs
+++ b/tests/posix/cat.rs
@@ -168,8 +168,7 @@ fn test_squeeze_blank_before_numbering() {
     }
 }
 
-
-
+#[cfg(unix)]
 #[test]
 fn test_domain_socket() {
     use std::thread;

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -40,6 +40,7 @@ use std::env;
 use std::ffi::{OsStr, OsString};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Result, Write};
+#[cfg(unix)]
 use std::os::unix::ffi::OsStringExt;
 #[cfg(unix)]
 use std::os::unix::fs::symlink as symlink_file;
@@ -546,6 +547,7 @@ impl UCommand {
     }
 
     /// like arg(...), but uses the contents of the file at the provided relative path as the argument
+    #[cfg(unix)]
     pub fn arg_fixture<S: AsRef<OsStr>>(&mut self, file_rel_path: S) -> &mut UCommand {
         let contents = read_scenario_fixture(&self.tmpd, file_rel_path);
         self.arg(OsString::from_vec(contents))


### PR DESCRIPTION
Not sure if we really care about this, so I'm making it a pull request.  I have essentially abstracted `RawFd` into `RawObject`, which is a `RawFd` on Unix and a `RawHandle` on Windows (I may add support for `RawSocket` as well, as I am thinking about implementing `UtilRead` and `UtilWrite` for `TcpStream`).

Note that a few tests still fail for `cat` and `head` on Windows.  It may just have been because `git` replaced the line endings for the fixtures though.